### PR TITLE
[the-graph-editor] Fire graphInitialised event

### DIFF
--- a/the-graph-editor/the-graph-editor.html
+++ b/the-graph-editor/the-graph-editor.html
@@ -139,7 +139,7 @@
                 while (graph.outports[pub]) {
                   count++;
                   pub = item.port + count;
-                } 
+                }
                 var priNode = graph.getNode(item.process);
                 var metadata = {x:priNode.metadata.x+144, y:priNode.metadata.y};
                 graph.addOutport(pub, item.process, item.port, metadata);
@@ -268,6 +268,7 @@
         noflo.graph.loadJSON(this.graph, function(nofloGraph){
           this.buildInitialLibrary(nofloGraph);
           this.nofloGraph = nofloGraph;
+          this.fire('graphInitialised', this);
         }.bind(this));
       },
       buildInitialLibrary: function (nofloGraph) {


### PR DESCRIPTION
As the-graph-editor has null graph/nofloGraph properties until
the first time a graph is set, it's not possible for interested
parties to bind to events on the graph, or to know when they are
able to.

Add a graphInitialised event which those parties can listen for.
When it's fired, the listener knows the graph is "live" and can
be queried/bound to etc.

Fixes #203 