### PR TITLE
Use app-relative pointer coords when previewing edges

### DIFF
--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -164,11 +164,22 @@
       }
     },
     renderPreviewEdge: function (event) {
+      // get pointer position relative to the DOM node containing the editor
+      var appDomNode = this.props.app.getDOMNode();
+      var bounds = appDomNode.getBoundingClientRect();
+      var appDomNodeLeft = bounds.left;
+      var appDomNodeTop = bounds.top;
+
       var x = event.x || event.clientX || 0;
+      x -= appDomNodeLeft;
+
       var y = event.y || event.clientY || 0;
+      y -= appDomNodeTop;
+
       x -= this.props.app.state.offsetX || 0;
       y -= this.props.app.state.offsetY || 0;
       var scale = this.props.app.state.scale;
+
       this.setState({
         edgePreviewX: (x - this.props.app.state.x) / scale,
         edgePreviewY: (y - this.props.app.state.y) / scale
@@ -222,7 +233,7 @@
               outports: outports
             };
           }
-          
+
           var i, port, len;
           for (i=0, len=component.outports.length; i<len; i++) {
             port = component.outports[i];
@@ -423,14 +434,14 @@
         if (!node.metadata) {
           node.metadata = {};
         }
-        if (node.metadata.x === undefined) { 
-          node.metadata.x = 0; 
+        if (node.metadata.x === undefined) {
+          node.metadata.x = 0;
         }
-        if (node.metadata.y === undefined) { 
-          node.metadata.y = 0; 
+        if (node.metadata.y === undefined) {
+          node.metadata.y = 0;
         }
-        if (node.metadata.width === undefined) { 
-          node.metadata.width = TheGraph.config.nodeWidth; 
+        if (node.metadata.width === undefined) {
+          node.metadata.width = TheGraph.config.nodeWidth;
         }
         node.metadata.height = TheGraph.config.nodeHeight;
         if (TheGraph.config.autoSizeNode && componentInfo) {
@@ -541,7 +552,7 @@
       var iips = graph.initializers.map(function (iip) {
         var target = graph.getNode(iip.to.node);
         if (!target) { return; }
-        
+
         var targetPort = self.getNodeInport(graph, iip.to.node, iip.to.port, 0, target.component);
         var tX = target.metadata.x;
         var tY = target.metadata.y + targetPort.y;
@@ -570,8 +581,8 @@
         var label = key;
         var nodeKey = inport.process;
         var portKey = inport.port;
-        if (!inport.metadata) { 
-          inport.metadata = {x:0, y:0}; 
+        if (!inport.metadata) {
+          inport.metadata = {x:0, y:0};
         }
         var metadata = inport.metadata;
         if (!metadata.x) { metadata.x = 0; }
@@ -645,8 +656,8 @@
         var label = key;
         var nodeKey = outport.process;
         var portKey = outport.port;
-        if (!outport.metadata) { 
-          outport.metadata = {x:0, y:0}; 
+        if (!outport.metadata) {
+          outport.metadata = {x:0, y:0};
         }
         var metadata = outport.metadata;
         if (!metadata.x) { metadata.x = 0; }
@@ -837,6 +848,6 @@
       return TheGraph.factories.graph.createGraphContainerGroup.call(this, containerOptions, containerContents);
 
     }
-  }));  
+  }));
 
 })(this);

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -164,22 +164,11 @@
       }
     },
     renderPreviewEdge: function (event) {
-      // get pointer position relative to the DOM node containing the editor
-      var appDomNode = this.props.app.getDOMNode();
-      var bounds = appDomNode.getBoundingClientRect();
-      var appDomNodeLeft = bounds.left;
-      var appDomNodeTop = bounds.top;
-
       var x = event.x || event.clientX || 0;
-      x -= appDomNodeLeft;
-
       var y = event.y || event.clientY || 0;
-      y -= appDomNodeTop;
-
       x -= this.props.app.state.offsetX || 0;
       y -= this.props.app.state.offsetY || 0;
       var scale = this.props.app.state.scale;
-
       this.setState({
         edgePreviewX: (x - this.props.app.state.x) / scale,
         edgePreviewY: (y - this.props.app.state.y) / scale
@@ -233,7 +222,7 @@
               outports: outports
             };
           }
-
+          
           var i, port, len;
           for (i=0, len=component.outports.length; i<len; i++) {
             port = component.outports[i];
@@ -434,14 +423,14 @@
         if (!node.metadata) {
           node.metadata = {};
         }
-        if (node.metadata.x === undefined) {
-          node.metadata.x = 0;
+        if (node.metadata.x === undefined) { 
+          node.metadata.x = 0; 
         }
-        if (node.metadata.y === undefined) {
-          node.metadata.y = 0;
+        if (node.metadata.y === undefined) { 
+          node.metadata.y = 0; 
         }
-        if (node.metadata.width === undefined) {
-          node.metadata.width = TheGraph.config.nodeWidth;
+        if (node.metadata.width === undefined) { 
+          node.metadata.width = TheGraph.config.nodeWidth; 
         }
         node.metadata.height = TheGraph.config.nodeHeight;
         if (TheGraph.config.autoSizeNode && componentInfo) {
@@ -552,7 +541,7 @@
       var iips = graph.initializers.map(function (iip) {
         var target = graph.getNode(iip.to.node);
         if (!target) { return; }
-
+        
         var targetPort = self.getNodeInport(graph, iip.to.node, iip.to.port, 0, target.component);
         var tX = target.metadata.x;
         var tY = target.metadata.y + targetPort.y;
@@ -581,8 +570,8 @@
         var label = key;
         var nodeKey = inport.process;
         var portKey = inport.port;
-        if (!inport.metadata) {
-          inport.metadata = {x:0, y:0};
+        if (!inport.metadata) { 
+          inport.metadata = {x:0, y:0}; 
         }
         var metadata = inport.metadata;
         if (!metadata.x) { metadata.x = 0; }
@@ -656,8 +645,8 @@
         var label = key;
         var nodeKey = outport.process;
         var portKey = outport.port;
-        if (!outport.metadata) {
-          outport.metadata = {x:0, y:0};
+        if (!outport.metadata) { 
+          outport.metadata = {x:0, y:0}; 
         }
         var metadata = outport.metadata;
         if (!metadata.x) { metadata.x = 0; }
@@ -848,6 +837,6 @@
       return TheGraph.factories.graph.createGraphContainerGroup.call(this, containerOptions, containerContents);
 
     }
-  }));
+  }));  
 
 })(this);

--- a/the-graph/the-graph.js
+++ b/the-graph/the-graph.js
@@ -27,7 +27,7 @@
       focusAnimationDuration: 1500
     },
     factories: {}
-  }; 
+  };
 
   // React setup
   React.initializeTouchEvents(true);
@@ -47,12 +47,12 @@
     showTooltip: function (event) {
       if ( !this.shouldShowTooltip() ) { return; }
 
-      var tooltipEvent = new CustomEvent('the-graph-tooltip', { 
+      var tooltipEvent = new CustomEvent('the-graph-tooltip', {
         detail: {
           tooltip: this.props.label,
           x: event.clientX,
           y: event.clientY
-        }, 
+        },
         bubbles: true
       });
       this.getDOMNode().dispatchEvent(tooltipEvent);
@@ -60,7 +60,7 @@
     hideTooltip: function (event) {
       if ( !this.shouldShowTooltip() ) { return; }
 
-      var tooltipEvent = new CustomEvent('the-graph-tooltip-hide', { 
+      var tooltipEvent = new CustomEvent('the-graph-tooltip-hide', {
         bubbles: true
       });
       if (this._lifeCycleState === "MOUNTED") {
@@ -261,7 +261,7 @@
     return radius * Math.sin(2*Math.PI * percent);
   };
   var makeArcPath = function (startPercent, endPercent, radius) {
-    return [ 
+    return [
       "M", angleToX(startPercent, radius), angleToY(startPercent, radius),
       "A", radius, radius, 0, 0, 0, angleToX(endPercent, radius), angleToY(endPercent, radius)
     ].join(" ");
@@ -407,7 +407,7 @@
 
     return React.DOM.svg.apply(React.DOM.svg, args);
   };
-  
+
   TheGraph.getOffset = function(domNode){
     var getElementOffset = function(element){
       var offset = { top: 0, left: 0},
@@ -417,6 +417,11 @@
       }
       offset.top += (element.offsetTop || 0);
       offset.left += (element.offsetLeft || 0);
+
+      var bounds = element.getBoundingClientRect();
+      offset.top += bounds.top;
+      offset.left += bounds.left;
+
       parentOffset = getElementOffset(element.offsetParent);
       offset.top += parentOffset.top;
       offset.left += parentOffset.left;


### PR DESCRIPTION
The pointer coordinates used to draw the preview of an edge
(when the edge is being "pulled out" of a node) should be
relative to the DOM element containing the graph editor, rather
than relative to the whole view.

Fixes #206 