### PR TITLE
Add separate menu type for subgraphs

### DIFF
--- a/the-graph-editor/the-graph-editor.html
+++ b/the-graph-editor/the-graph-editor.html
@@ -205,6 +205,19 @@
               }
             },
             e4: pasteMenu
+          },
+          subgraph: {
+            actions: nodeActions,
+            s4: {
+              icon: "trash-o",
+              iconLabel: "delete",
+              action: nodeActions.delete
+            },
+            w4: {
+              icon: "copy",
+              iconLabel: "copy",
+              action:  nodeActions.copy
+            }
           }
         };
       },

--- a/the-graph/the-graph-graph.js
+++ b/the-graph/the-graph-graph.js
@@ -478,7 +478,8 @@
           selected: selected,
           error: (self.state.errorNodes[key] === true),
           showContext: self.props.showContext,
-          highlightPort: highlightPort
+          highlightPort: highlightPort,
+          subgraph: componentInfo ? componentInfo.subgraph : false
         };
 
         nodeOptions = TheGraph.merge(TheGraph.config.graph.node, nodeOptions);

--- a/the-graph/the-graph-node.js
+++ b/the-graph/the-graph-node.js
@@ -226,7 +226,8 @@
       // App.showContext
       this.props.showContext({
         element: this,
-        type: (this.props.export ? (this.props.isIn ? "graphInport" : "graphOutport") : "node"),
+        type: (this.props.export ? (this.props.isIn ? "graphInport" : "graphOutport") :
+               this.props.subgraph ? "subgraph" : "node"),
         x: x,
         y: y,
         graph: this.props.graph,


### PR DESCRIPTION
Allows apps to add options to subgraph nodes that shouldn't be available for other nodes